### PR TITLE
Improvements on Terraform-AKS documentation

### DIFF
--- a/azure-aks/README.md
+++ b/azure-aks/README.md
@@ -77,18 +77,6 @@ The Terraform script creates the following resources:
 
 ---
 
-## Overview of the Script
-
-The Terraform script creates the following resources:
-
-1. **Resource Group** – A dedicated group for managing all resources.
-2. **Virtual Network (VNET) and Subnets** – For network configuration.
-3. **Azure Kubernetes Service (AKS) Cluster** – The core infrastructure for hosting Bold Reports.
-4. **PostgreSQL Server** – The database for storing Bold Reports configurations and data.
-5. **Storage Account with NFS** – To store Required application data.
-
----
-
 ## Deployment Steps
 
 ### Step 1: Clone the Terraform Scripts Repository

--- a/azure-aks/README.md
+++ b/azure-aks/README.md
@@ -10,12 +10,70 @@ Before proceeding, ensure the following tools and resources are installed and av
 
 1. **Terraform CLI**  
    Install Terraform from the official guide: [Terraform Installation Guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-2. **[Azure Subscription](https://azure.microsoft.com/en-us/pricing/purchase-options/azure-account) with An [Azure Application Registry](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)**
+2. **Azure CLI**
+
+   Certain steps in this deployment—such as Azure DNS record mapping and AKS public IP DNS name assignment—require the **Azure CLI (`az`)** to be installed and available on your system.
+
+   ### ✅ Check if Azure CLI is Installed
+
+   Run the following command in your terminal:
+
+   #### Linux / macOS / Windows
+
+   ```sh
+   az --version
+   ```
+
+   ---
+
+   ### 📦 Install Azure CLI
+
+   Follow the instructions below based on your operating system:
+
+   #### Linux (Debian/Ubuntu)
+
+   ```sh
+   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+   ```
+
+   #### macOS (Homebrew)
+
+   ```sh
+   brew update && brew install azure-cli
+   ```
+
+   #### Windows
+
+   Download and run the MSI installer from:  
+   👉 [https://aka.ms/installazurecliwindows](https://aka.ms/installazurecliwindows)
+
+   For more details and installation options, refer to the official guide:  
+   🔗 [Azure CLI Installation Guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+
+   ---
+
+   ### ⚠️ Note
+
+   If you do **not** provide a custom `app_base_url`, the Azure CLI is **required** by this script for automated DNS configuration steps.  
+   If Azure CLI is **unavailable**, some steps of `terraform apply` will **fail**.
+3. **[Azure Subscription](https://azure.microsoft.com/en-us/pricing/purchase-options/azure-account) with An [Azure Application Registry](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)**
    <br>Ensure your Azure Application Registry has the necessary permissions defined in the [Policy.json](policy.json) file.
    - Client ID
    - Client Secret
    - Tenant ID
    - Subscription ID
+
+---
+
+## Overview of the Script
+
+The Terraform script creates the following resources:
+
+1. **Resource Group** – A dedicated group for managing all resources.
+2. **Virtual Network (VNET) and Subnets** – For network configuration.
+3. **Azure Kubernetes Service (AKS) Cluster** – The core infrastructure for hosting Bold Reports.
+4. **PostgreSQL Server** – The database for storing Bold Reports configurations and data.
+5. **Storage Account with NFS** – To store Required application data.
 
 ---
 
@@ -63,7 +121,7 @@ Other than this, we need to add the following environment variables either as a 
 | TF_VAR_db_password           | db-password                   | Yes      | **Database password** <br> - Your password must be at least 8 characters and at most 128 characters.<br> - Your password must contain characters from three of the following categories<br> - English uppercase letters, English lowercase letters, numbers (0-9), and non-alphanumeric characters (!, $, #, %, etc.).<br> - Your password cannot contain all or part of the login name. Part of a login name is defined as three or more consecutive alphanumeric characters.                                 |
 | TF_VAR_boldreports_email     | boldreports-email             | Yes      | Bold Reports admin Email                               |
 | TF_VAR_boldreports_password  | boldreports-password          | Yes      | **Bold Reports admin password**<br> - Your password must be at least 8 characters and at most 128 characters.<br> - Your password must contain characters from three of the following categories<br> - English uppercase letters, English lowercase letters, numbers (0-9), and non-alphanumeric characters (!, $, #, %, etc.)|
-| TF_VAR_boldreports_unlock_key| boldreports-unlock-key        | Yes      | Unlock key for Bold Reports                            |
+| TF_VAR_boldreports_unlock_key| boldreports-unlock-key        | No      | **Optional:-** Provide a license key for automatic activation. If you leave this empty, you can manually upload or select a trial license in the Bold Reports startup page after deployment.<br>   **Note:-** Trail license valid for 30 days alone.                      |
 | TF_VAR_app_base_url          | app-base-url                  | No       | The base URL for the Bold Reports application (e.g., https://example.com).<br>If left empty, Azure DNS with randomly generated characters will be used for application hosting(e.g., http://abcd.eastus2.cloudapp.azure.com).<p><br> **Note:-**  If app_base_url is left empty, you must install Azure CLI on your machine for Azure DNS mapping.[Azure CLI Installation Guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)                                                |
 | TF_VAR_cloudflare_api_token  | cloudflare-api-token          | No       | Cloudflare API Token for DNS mapping on cloudflare|
 | TF_VAR_cloudflare_zone_id    | cloudflare-zone-id            | No       | Cloudflare zone ID for DNS mapping on cloudflare  |

--- a/azure-aks/README.md
+++ b/azure-aks/README.md
@@ -10,52 +10,10 @@ Before proceeding, ensure the following tools and resources are installed and av
 
 1. **Terraform CLI**  
    Install Terraform from the official guide: [Terraform Installation Guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-2. **Azure CLI**
+2. **Azure CLI**  
+   If you don’t provide a custom `app_base_url`, Azure CLI is required for automated DNS setup. Without it, terraform apply may fail.
 
-   Certain steps in this deployment—such as Azure DNS record mapping and AKS public IP DNS name assignment—require the **Azure CLI (`az`)** to be installed and available on your system.
-
-   ### ✅ Check if Azure CLI is Installed
-
-   Run the following command in your terminal:
-
-   #### Linux / macOS / Windows
-
-   ```sh
-   az --version
-   ```
-
-   ---
-
-   ### 📦 Install Azure CLI
-
-   Follow the instructions below based on your operating system:
-
-   #### Linux (Debian/Ubuntu)
-
-   ```sh
-   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-   ```
-
-   #### macOS (Homebrew)
-
-   ```sh
-   brew update && brew install azure-cli
-   ```
-
-   #### Windows
-
-   Download and run the MSI installer from:  
-   👉 [https://aka.ms/installazurecliwindows](https://aka.ms/installazurecliwindows)
-
-   For more details and installation options, refer to the official guide:  
-   🔗 [Azure CLI Installation Guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
-
-   ---
-
-   ### ⚠️ Note
-
-   If you do **not** provide a custom `app_base_url`, the Azure CLI is **required** by this script for automated DNS configuration steps.  
-   If Azure CLI is **unavailable**, some steps of `terraform apply` will **fail**.
+   Install Azure CLI from the official guide:  [Azure CLI Installation Guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 3. **[Azure Subscription](https://azure.microsoft.com/en-us/pricing/purchase-options/azure-account) with An [Azure Application Registry](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)**
    <br>Ensure your Azure Application Registry has the necessary permissions defined in the [Policy.json](policy.json) file.
    - Client ID
@@ -109,7 +67,7 @@ Other than this, we need to add the following environment variables either as a 
 | TF_VAR_db_password           | db-password                   | Yes      | **Database password** <br> - Your password must be at least 8 characters and at most 128 characters.<br> - Your password must contain characters from three of the following categories<br> - English uppercase letters, English lowercase letters, numbers (0-9), and non-alphanumeric characters (!, $, #, %, etc.).<br> - Your password cannot contain all or part of the login name. Part of a login name is defined as three or more consecutive alphanumeric characters.                                 |
 | TF_VAR_boldreports_email     | boldreports-email             | Yes      | Bold Reports admin Email                               |
 | TF_VAR_boldreports_password  | boldreports-password          | Yes      | **Bold Reports admin password**<br> - Your password must be at least 8 characters and at most 128 characters.<br> - Your password must contain characters from three of the following categories<br> - English uppercase letters, English lowercase letters, numbers (0-9), and non-alphanumeric characters (!, $, #, %, etc.)|
-| TF_VAR_boldreports_unlock_key| boldreports-unlock-key        | No      | **Optional:-** Provide a license key for automatic activation. If you leave this empty, you can manually upload or select a trial license in the Bold Reports startup page after deployment.<br>   **Note:-** Trail license valid for 30 days alone.                      |
+| TF_VAR_boldreports_unlock_key| boldreports-unlock-key        | Yes      | **Optional:-** Provide a license key for automatic activation. If you leave this empty, you can manually upload or select a trial license in the Bold Reports startup page after deployment.<br>   **Note:-** Trail license valid for 30 days alone.                      |
 | TF_VAR_app_base_url          | app-base-url                  | No       | The base URL for the Bold Reports application (e.g., https://example.com).<br>If left empty, Azure DNS with randomly generated characters will be used for application hosting(e.g., http://abcd.eastus2.cloudapp.azure.com).<p><br> **Note:-**  If app_base_url is left empty, you must install Azure CLI on your machine for Azure DNS mapping.[Azure CLI Installation Guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)                                                |
 | TF_VAR_cloudflare_api_token  | cloudflare-api-token          | No       | Cloudflare API Token for DNS mapping on cloudflare|
 | TF_VAR_cloudflare_zone_id    | cloudflare-zone-id            | No       | Cloudflare zone ID for DNS mapping on cloudflare  |


### PR DESCRIPTION
## Summary

This PR introduces improvements the clarity of the Terraform-AKS documentation.

This update makes the deployment more flexible by allowing users to proceed without a license key and clarifies the dependency on the Azure CLI.

---

## ✅ Changes Made

### Documentation Updates (`README.md`)
- **Azure CLI Prerequisite:**
  - A new, detailed prerequisite section for the **Azure CLI (`az`)** has been added.
  - This section explains *why* the CLI is necessary (for automated DNS mapping when `app_base_url` is not set).
  - It includes simple commands for users to check if `az` is already installed on Linux, macOS, and Windows.
  - Provides direct installation instructions for major platforms to guide users who do not have it installed.
- **Optional License Key:**
  - The `boldreports_unlock_key` variable is now marked as **`Required: No`** in the prerequisites table.
  - Added a clear description explaining that if the key is omitted, the user can manually upload or select a 30-day trial license during the application startup.

---

## Impact
- **Enhanced Clarity:** The documentation is now more comprehensive, setting clearer expectations for dependencies and deployment options.